### PR TITLE
Fix: Use presigned URI uploads instead of large payload size in App Release upload

### DIFF
--- a/src/lib/api/app_release.remote.ts
+++ b/src/lib/api/app_release.remote.ts
@@ -10,6 +10,15 @@ import * as v from "valibot"
 
 import { requireAuthMaybeAdmin } from "./common"
 
+const PrepareApkUploadSchema = v.object({
+  versionName: v.pipe(v.string(), v.minLength(1, "Version Name is required")),
+  buildNumber: v.pipe(v.string(), v.toNumber()),
+  filename: v.pipe(
+    v.string(),
+    v.check((val) => val.endsWith(".apk"), "Uploaded file must be an .apk")
+  )
+})
+
 const CreateAppReleaseSchema = v.object({
   versionName: v.pipe(v.string(), v.minLength(1, "Version Name is required")),
   buildNumber: v.pipe(v.string(), v.toNumber()),
@@ -18,8 +27,12 @@ const CreateAppReleaseSchema = v.object({
     v.optional(v.string(), ""),
     v.transform((value) => value === "on" || value === "true")
   ),
-  apkFile: v.file()
+  apkFilePath: v.pipe(v.string(), v.minLength(1, "File path is required"))
 })
+
+const buildApkFileName = (versionName: string, buildNumber: number, filename: string): string => {
+  return `${versionName}-${buildNumber}/${filename}`
+}
 
 /**
  * Fetch all app releases
@@ -39,32 +52,53 @@ export const fetchAppReleases = query(async () => {
 })
 
 /**
- * Creates a new app release
+ * Step 1: Validates metadata & creates signed upload URL
+ * Required ADMIN
+ */
+export const prepareApkUpload = query(PrepareApkUploadSchema, async (data) => {
+  let TAG = `Remote: prepareApkUpload(${data.versionName}-${data.buildNumber})`
+  console.time(TAG)
+
+  const { locals } = getRequestEvent()
+  const { supabase } = await requireAuthMaybeAdmin(locals, true)
+  const { versionName, buildNumber, filename } = data
+
+  const filePath = buildApkFileName(versionName, buildNumber, filename)
+
+  const { data: uploadData, error: uploadError } = await supabase.storage
+    .from("apk_releases")
+    .createSignedUploadUrl(filePath, { upsert: false })
+
+  console.timeEnd(TAG)
+
+  if (uploadError !== null) {
+    console.error("Failed to create signed upload URL", uploadError)
+    return { success: false, data: null, message: "Failed to generate upload URL", status: 500 }
+  }
+
+  return {
+    success: true,
+    data: {
+      signedUrl: uploadData.signedUrl,
+      token: uploadData.token,
+      filePath
+    },
+    status: 200
+  }
+})
+
+/**
+ * Step 2: Creates a new app release after upload is done
  * Requires ADMIN
  */
 export const createAppRelease = form(CreateAppReleaseSchema, async (data, issue) => {
-  let TAG = `Remote: createAppRelease(${data})`
+  let TAG = `Remote: createAppRelease(${data.versionName}-${data.buildNumber})`
   console.time(TAG)
 
   const { locals } = getRequestEvent()
   const { claims, supabase } = await requireAuthMaybeAdmin(locals, true)
 
-  const { versionName, buildNumber, releaseNotes, isMandatory, apkFile } = data
-
-  if (!apkFile.name.endsWith(".apk")) {
-    invalid(issue.apkFile("Uploaded file must be an .apk"))
-  }
-
-  const filePath = `${versionName}-${buildNumber}/${apkFile.name}`
-  const { error: uploadError } = await supabase.storage
-    .from("apk_releases")
-    .upload(filePath, apkFile, { cacheControl: "3600", upsert: false })
-
-  if (uploadError !== null) {
-    console.error("Failed to upload APK", uploadError)
-    console.timeEnd(TAG)
-    return { success: false, data: null, message: "Failed to upload APK", status: 500 }
-  }
+  const { versionName, buildNumber, releaseNotes, isMandatory, apkFilePath } = data
 
   const newReleaseResult = await createAppReleaseDb(
     locals,
@@ -72,14 +106,13 @@ export const createAppRelease = form(CreateAppReleaseSchema, async (data, issue)
     buildNumber,
     releaseNotes,
     isMandatory,
-    filePath
+    apkFilePath
   )
 
   if (newReleaseResult.error !== null) {
     console.error("Failed to create app release", newReleaseResult.error)
-
     console.log("Removing stale uploaded apk")
-    await supabase.storage.from("apk_releases").remove([filePath])
+    await supabase.storage.from("apk_releases").remove([apkFilePath])
 
     if (newReleaseResult.constraintName === "app_release_buildNumber_unique") {
       console.timeEnd(TAG)
@@ -89,6 +122,8 @@ export const createAppRelease = form(CreateAppReleaseSchema, async (data, issue)
     console.timeEnd(TAG)
     return { success: false, data: null, message: "Failed to create app release", status: 500 }
   }
+
+  fetchAppReleases().refresh()
 
   console.timeEnd(TAG)
   return { success: true, data: newReleaseResult.data, status: 201 }

--- a/src/routes/(dashboard)/admin/releases/+page.svelte
+++ b/src/routes/(dashboard)/admin/releases/+page.svelte
@@ -6,7 +6,7 @@ import { Button } from "@/lib/components/ui/button"
 import { Skeleton } from "@/lib/components/ui/skeleton"
 
 import { columns } from "./columns"
-import ReleaseUploadDialog from "./UploadReleaseButton.svelte"
+import UploadReleaseButton from "./UploadReleaseButton.svelte"
 </script>
 
 <svelte:head>
@@ -17,7 +17,7 @@ import ReleaseUploadDialog from "./UploadReleaseButton.svelte"
 <div class="h-auto space-y-8 px-4 py-8">
   <PageHeader title="App Releases" description="Keep employees app updated">
     {#snippet action()}
-      <ReleaseUploadDialog />
+      <UploadReleaseButton />
     {/snippet}
   </PageHeader>
 

--- a/src/routes/(dashboard)/admin/releases/UploadReleaseButton.svelte
+++ b/src/routes/(dashboard)/admin/releases/UploadReleaseButton.svelte
@@ -1,4 +1,3 @@
-<!-- src/routes/admin/releases/components/release-upload-dialog.svelte -->
 <script lang="ts">
 import { type RemoteFormIssue } from "@sveltejs/kit"
 
@@ -9,18 +8,30 @@ import * as Field from "@ui/field"
 import { Input } from "@ui/input"
 import { Textarea } from "@ui/textarea"
 
-import { createAppRelease } from "$lib/api/app_release.remote"
+import { createAppRelease, prepareApkUpload } from "$lib/api/app_release.remote"
 
 import LoaderCircle from "@lucide/svelte/icons/loader-circle"
 import UploadCloudIcon from "@lucide/svelte/icons/upload-cloud"
+import { tick } from "svelte"
 import { toast } from "svelte-sonner"
 
 let dialogOpen = $state(false)
+let selectedFile = $state<File | null>(null)
+let isUploading = $state(false)
+
+function handleFileChange(event: Event) {
+  const target = event.target as HTMLInputElement
+  if (target.files && target.files.length > 0) {
+    selectedFile = target.files[0]
+  } else {
+    selectedFile = null
+  }
+}
 </script>
 
 {#snippet errorListSnippet(issues: RemoteFormIssue[])}
   {#if issues.length > 0}
-    <ul>
+    <ul class="list-inside list-disc text-xs text-destructive">
       {#each issues as issue}
         <li>{issue.message}</li>
       {/each}
@@ -46,31 +57,77 @@ let dialogOpen = $state(false)
 
     <form
       {...createAppRelease.enhance(async (form) => {
+        if (!selectedFile) {
+          toast.error("Please select an APK file")
+          return
+        }
+
+        if (!selectedFile.name.endsWith(".apk")) {
+          toast.error("Uploaded file must be an .apk")
+          return
+        }
+
         const toastId = toast.loading("Uploading release...")
-        console.debug("Submitting data", {
-          ...form.fields.value()
-        })
+        isUploading = true
 
         try {
+          // 1. Request presigned  upload URL
+          const values = form.fields.value()
+          const prepareResult = await prepareApkUpload({
+            versionName: values.versionName ?? "",
+            buildNumber: values.buildNumber ?? "0",
+            filename: selectedFile.name
+          })
+
+          if (!prepareResult.success || !prepareResult.data) {
+            throw new Error(prepareResult.message || "Failed to initialize upload ticket")
+          }
+
+          console.log("Upload Prepare result", prepareResult)
+          const { signedUrl, filePath } = prepareResult.data
+
+          // 2. Direct binary transfer from browser to Supabase Storage
+          toast.loading("Uploading APK file...", { id: toastId })
+          const uploadResponse = await fetch(signedUrl, {
+            method: "PUT",
+            headers: {
+              "Content-Type": "application/vnd.android.package-archive"
+            },
+            body: selectedFile
+          })
+
+          if (!uploadResponse.ok) {
+            throw new Error(`Direct storage upload failed: ${uploadResponse.statusText}`)
+          }
+
+          console.log("Upload response", uploadResponse)
+
+          // 3. Set the verified filePath in the form payload
+          form.fields.apkFilePath.set(filePath)
+          createAppRelease.fields.apkFilePath.set(filePath)
+
+          // // wait for svelte to flush the updates to DOM
+          await tick()
+
+          // 4. Submit form
+          toast.loading("Publishing release...", { id: toastId })
+          console.debug("Submitting data", {
+            ...form.fields.value()
+          })
+
           if (await form.submit()) {
             const result = form.result
-            if (!result) {
-              toast.error("Unexpected Error", { id: toastId })
-              console.error("Unexpected Error: result is null even when submit succeeded", result)
-              return
-            }
-
-            // handle unsuccess
-            if (result && (!result.data || !result.success)) {
-              throw result.message
+            if (!result || !result.data || !result.success) {
+              throw new Error(result?.message || "Failed to finalize release")
             }
 
             form.element.reset()
+            selectedFile = null
             dialogOpen = false
 
             toast.success("Release uploaded successfully", {
               id: toastId,
-              description: `Version ${result.data.versionName} (${result.data.buildNumber}) has been published`
+              description: `Version ${result.data.versionName}-${result.data.buildNumber} has been published`
             })
             console.debug("Release uploaded", result.data)
           } else {
@@ -83,9 +140,14 @@ let dialogOpen = $state(false)
             id: toastId
           })
           console.error(error)
+        } finally {
+          isUploading = false
         }
-      })}
-      enctype="multipart/form-data">
+      })}>
+      {let apkFilePath = $derived(createAppRelease.fields.apkFilePath.value() ?? "")}
+      <!-- Hidden field carrying storage location to avoid binary payload -->
+      <input hidden {...createAppRelease.fields.apkFilePath.as("text")} value={apkFilePath} />
+
       <Field.Group>
         <Field.Set>
           <Field.Group>
@@ -100,7 +162,7 @@ let dialogOpen = $state(false)
                 <Input
                   placeholder="e.g. 1.2.0"
                   required
-                  disabled={createAppRelease.pending > 0}
+                  disabled={isUploading || createAppRelease.pending > 0}
                   {...createAppRelease.fields.versionName.as("text")} />
               </Field.Field>
 
@@ -114,7 +176,7 @@ let dialogOpen = $state(false)
                 <Input
                   placeholder="e.g. 15"
                   required
-                  disabled={createAppRelease.pending > 0}
+                  disabled={isUploading || createAppRelease.pending > 0}
                   {...createAppRelease.fields.buildNumber.as("text")}
                   type="number" />
               </Field.Field>
@@ -130,7 +192,7 @@ let dialogOpen = $state(false)
               {const releaseNotesField = createAppRelease.fields.releaseNotes.as("text")}
               <Textarea
                 rows={3}
-                disabled={createAppRelease.pending > 0}
+                disabled={isUploading || createAppRelease.pending > 0}
                 name={releaseNotesField.name}
                 aria-invalid={releaseNotesField["aria-invalid"]} />
             </Field.Field>
@@ -139,23 +201,22 @@ let dialogOpen = $state(false)
               <Field.Content>
                 <Field.Label for="apkFile">APK File</Field.Label>
                 <Field.Error>
-                  {@render errorListSnippet(createAppRelease.fields.apkFile.issues() ?? [])}
+                  {@render errorListSnippet(createAppRelease.fields.apkFilePath.issues() ?? [])}
                 </Field.Error>
               </Field.Content>
-              {const apkFileField = createAppRelease.fields.apkFile.as("file")}
               <Input
                 type="file"
-                name={apkFileField.name}
-                aria-invalid={apkFileField["aria-invalid"]}
+                id="apkFile"
                 accept=".apk"
                 required
-                disabled={createAppRelease.pending > 0} />
+                disabled={isUploading || createAppRelease.pending > 0}
+                onchange={handleFileChange} />
             </Field.Field>
 
             <Field.Field orientation="horizontal" class="items-center gap-2">
               {const isMandatoryField = createAppRelease.fields.isMandatory.as("text")}
               <Checkbox
-                disabled={createAppRelease.pending > 0}
+                disabled={isUploading || createAppRelease.pending > 0}
                 name={isMandatoryField.name}
                 aria-invalid={isMandatoryField["aria-invalid"]} />
               <Field.Label for="isMandatory">Mandatory Update</Field.Label>
@@ -171,13 +232,13 @@ let dialogOpen = $state(false)
             variant="outline"
             type="button"
             onclick={() => (dialogOpen = false)}
-            disabled={createAppRelease.pending > 0}>
+            disabled={isUploading || createAppRelease.pending > 0}>
             Cancel
           </Button>
-          <Button disabled={createAppRelease.pending > 0} type="submit">
-            {#if createAppRelease.pending > 0}
-              <LoaderCircle class="animate-spin" />
-              Uploading...
+          <Button disabled={isUploading || createAppRelease.pending > 0} type="submit">
+            {#if isUploading || createAppRelease.pending > 0}
+              <LoaderCircle class="mr-2 h-4 w-4 animate-spin" />
+              Processing...
             {:else}
               Deploy Release
             {/if}

--- a/src/routes/(dashboard)/admin/releases/columns.ts
+++ b/src/routes/(dashboard)/admin/releases/columns.ts
@@ -1,5 +1,19 @@
+import { renderSnippet } from "@/lib/components/ui/data-table"
+import { DateTime } from "luxon"
+import { createRawSnippet } from "svelte"
+
 import type { AppRelease } from "@/lib/types"
 import type { ColumnDef } from "@tanstack/table-core"
+
+// Truncate helper snippet
+const truncatedCellSnippet = createRawSnippet<[{ text: string; maxWidthClass?: string }]>(
+  (getProps) => {
+    const { text, maxWidthClass = "max-w-[350px]" } = getProps()
+    return {
+      render: () => `<div class="${maxWidthClass} truncate" title="${text}">${text}</div>`
+    }
+  }
+)
 
 export const columns: ColumnDef<AppRelease>[] = [
   {
@@ -17,6 +31,22 @@ export const columns: ColumnDef<AppRelease>[] = [
   {
     accessorKey: "releaseNotes",
     header: "Release Notes",
-    cell: (info) => info.getValue()
+    cell: ({ row }) => {
+      return renderSnippet(truncatedCellSnippet, { text: row.original.releaseNotes })
+    }
+  },
+  {
+    accessorKey: "createdAt",
+    header: "Created At",
+    cell: ({ row }) => {
+      return row.original.createdAt.toLocaleString(DateTime.TIME_SIMPLE)
+    }
+  },
+  {
+    accessorKey: "updatedAt",
+    header: "Updated At",
+    cell: ({ row }) => {
+      return row.original.createdAt.toLocaleString(DateTime.TIME_SIMPLE)
+    }
   }
 ]

--- a/src/routes/(dashboard)/api/pois/+server.ts
+++ b/src/routes/(dashboard)/api/pois/+server.ts
@@ -4,14 +4,24 @@ import * as s from "@/lib/db/schema"
 import { handleApiError, requireApiAuth } from "@/lib/server/api"
 import { db } from "@/lib/server/db/common"
 import { VisitType } from "@/lib/types"
-import { and, asc, eq } from "drizzle-orm"
+import { and, asc, eq, inArray } from "drizzle-orm"
 import * as v from "valibot"
 
 import type { RequestHandler } from "./$types"
 import type { ApiIssue } from "@/lib/server/api"
 
 const getPoiSchema = v.object({
-  locationId: v.pipe(v.string(), v.uuid("Invalid location ID")),
+  locationIds: v.pipe(
+    v.string("locationIds is required"),
+    v.transform((val) =>
+      val
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean)
+    ),
+    v.array(v.pipe(v.string(), v.uuid("Invalid location ID"))),
+    v.minLength(1, "At least one location ID is required")
+  ),
   visitType: v.optional(v.enum(VisitType, "Invalid visit type"))
 })
 
@@ -27,7 +37,10 @@ export const GET: RequestHandler = async ({ request, url, locals }) => {
   try {
     const { user, apiSupabase } = await requireApiAuth(request, locals.supabase)
 
-    const params = Object.fromEntries(url.searchParams.entries())
+    const params = {
+      locationIds: url.searchParams.get("locationIds") ?? "",
+      visitType: url.searchParams.get("visitType") ?? undefined
+    }
     const parsed = v.safeParse(getPoiSchema, params)
 
     if (!parsed.success) {
@@ -47,14 +60,14 @@ export const GET: RequestHandler = async ({ request, url, locals }) => {
       throw error(400, { message: "Invalid payload", data: issues })
     }
 
-    const { locationId, visitType } = parsed.output
+    const { locationIds, visitType } = parsed.output
 
-    const conditions = [eq(s.poi.locationId, locationId)]
+    const conditions = [inArray(s.poi.locationId, locationIds)]
     if (visitType) conditions.push(eq(s.poi.type, visitType))
 
     const pois = await db.query.poi.findMany({
       where: and(...conditions),
-      orderBy: [asc(s.poi.name)],
+      orderBy: [asc(s.poi.locationId), asc(s.poi.name)],
       with: { location: { columns: { id: true, name: true } } }
     })
 

--- a/src/routes/(dashboard)/api/pois/[poiId=uuid]/+server.ts
+++ b/src/routes/(dashboard)/api/pois/[poiId=uuid]/+server.ts
@@ -25,7 +25,7 @@ export const GET: RequestHandler = async ({ request, locals, params }) => {
       where: eq(s.poi.id, poiId)
     })
 
-    return json({ success: true, data: poi })
+    return json({ success: true, data: poi ?? null })
   } catch (err: any) {
     throw handleApiError(err)
   } finally {

--- a/todo.txt
+++ b/todo.txt
@@ -22,3 +22,4 @@ x 2026-08-07 2026-08-07 create visit api route
 x 2026-08-22 2026-08-10 list all employees in travlling with for the meantime
 (A) 2026-08-10 record all amounts recorded in visits into travel plan targets
 x 2026-08-23 2026-08-22 use presigned URL upload instead of transferring file with remote form
+x 2026-08-23 2026-08-23 support for multiple locationIds in listing POIs

--- a/todo.txt
+++ b/todo.txt
@@ -18,6 +18,7 @@ x 2026-08-19 2026-08-06 do the migrate and contract phase for visits and POI tab
 (B) 2026-08-07 add POI distance calculation
 x 2026-08-07 2026-08-07 list POI api route
 x 2026-08-07 2026-08-07 create visit api route
-(A) 2026-08-10 implement per tier expensing
+(B) 2026-08-10 implement per tier expensing
 x 2026-08-22 2026-08-10 list all employees in travlling with for the meantime
 (A) 2026-08-10 record all amounts recorded in visits into travel plan targets
+x 2026-08-23 2026-08-22 use presigned URL upload instead of transferring file with remote form


### PR DESCRIPTION
Vercel only allows a max of 4.5 MB payload size for remote functions, and APKs above that size were failing. Now we use pre-signed URIs for direct uploads.

### Other changes

- limit release notes columns with in app releases listing
- accept multiple `locationIds` for listing POIs (breaking change)

### Known Issues

- The submit success after second click, due to the `apkFilePath` field not being updated just after the upload, only after second click it is sync properly on the page, and it requires the user to manually delete the uploaded file from storage. Works for now

Closes #28